### PR TITLE
Reverted regression to error from fail 

### DIFF
--- a/src/Deepblue/Database/GIS/Internal.hs
+++ b/src/Deepblue/Database/GIS/Internal.hs
@@ -72,7 +72,7 @@ loadExtension :: Database -> T.Text -> IO (Either (Error, SD.Utf8) ())
 loadExtension d l = do
   res <- SD.loadExtension d (toUtf8 l)
   case res of
-    Left (_,m) -> (error $ "loadExtension: " ++ utf8toString m) >> return res
+    Left (_,m) -> (fail $ "loadExtension: " ++ utf8toString m) >> return res
     Right _ -> return res
 
 


### PR DESCRIPTION
Failure is the only way to trigger alternatives for `Alternative IO` or really `MonadPlus IO`. Yetch.
So the real solution is to create our own monad for the `GIS` type and "do this better"(tm).
